### PR TITLE
Fix bug when specifying headers multiple times

### DIFF
--- a/surl/__init__.py
+++ b/surl/__init__.py
@@ -30,6 +30,14 @@ __all__ = [
     "main",
 ]
 
+
+DEFAULT_HEADERS = {
+    "User-Agent": "surl/{}".format(os.environ.get("SNAP_VERSION", "devel")),
+    "Accept": "application/json, application/hal+json",
+    "Content-Type": "application/json",
+    "Cache-Control": "no-cache",
+}
+
 CONSTANTS = {
     "local": {
         "sso_location": os.environ.get("SURL_SSO_LOCATION", "login.staging.ubuntu.com"),
@@ -426,6 +434,7 @@ def main():
     except CliDone:
         return 0
 
+    headers = DEFAULT_HEADERS.copy()
     if url is None:
         if config.store_type == "snapcraft":
             url = "{}/api/v2/tokens/whoami".format(
@@ -437,17 +446,15 @@ def main():
             )
 
     auth_header = get_authorization_header(config.root, config.discharge)
+    headers.update(auth_header)
 
     # -s hides progress bar and errors, -S brings the errors back, -L follows
     # redirects, and --output - prints binary output to terminal
-    arguments = [
-        "curl",
-        "-sSL",
-        "--output",
-        "-",
-        "-H",
-        f"Authorization: {auth_header['Authorization']}",
-    ]
+    arguments = ["curl", "-sSL", "--output", "-"]
+
+    for header, value in headers.items():
+        arguments.append("-H")
+        arguments.append(f"{header}: {value}")
 
     arguments.extend(remainder)
     arguments.append(url)

--- a/surl/__init__.py
+++ b/surl/__init__.py
@@ -30,14 +30,6 @@ __all__ = [
     "main",
 ]
 
-
-DEFAULT_HEADERS = {
-    "User-Agent": "surl/{}".format(os.environ.get("SNAP_VERSION", "devel")),
-    "Accept": "application/json, application/hal+json",
-    "Content-Type": "application/json",
-    "Cache-Control": "no-cache",
-}
-
 CONSTANTS = {
     "local": {
         "sso_location": os.environ.get("SURL_SSO_LOCATION", "login.staging.ubuntu.com"),
@@ -434,7 +426,6 @@ def main():
     except CliDone:
         return 0
 
-    headers = DEFAULT_HEADERS.copy()
     if url is None:
         if config.store_type == "snapcraft":
             url = "{}/api/v2/tokens/whoami".format(
@@ -446,15 +437,10 @@ def main():
             )
 
     auth_header = get_authorization_header(config.root, config.discharge)
-    headers.update(auth_header)
 
     # -s hides progress bar and errors, -S brings the errors back, -L follows
     # redirects, and --output - prints binary output to terminal
-    arguments = ["curl", "-sSL", "--output", "-"]
-
-    for header, value in headers.items():
-        arguments.append("-H")
-        arguments.append(f"{header}: {value}")
+    arguments = ["curl", "-sSL", "--output", "-", "-H", f"Authorization: {auth_header['Authorization']}"]
 
     arguments.extend(remainder)
     arguments.append(url)

--- a/surl/__init__.py
+++ b/surl/__init__.py
@@ -32,10 +32,10 @@ __all__ = [
 
 
 DEFAULT_HEADERS = {
-    "User-Agent": "surl/{}".format(os.environ.get("SNAP_VERSION", "devel")),
-    "Accept": "application/json, application/hal+json",
-    "Content-Type": "application/json",
-    "Cache-Control": "no-cache",
+    "user-agent": "surl/{}".format(os.environ.get("SNAP_VERSION", "devel")),
+    "accept": "application/json, application/hal+json",
+    "content-type": "application/json",
+    "ccache-control": "no-cache",
 }
 
 CONSTANTS = {
@@ -433,6 +433,12 @@ def main():
         return 1
     except CliDone:
         return 0
+    
+    parser.add_argument(
+        "-H", "--header", action="append", default=[], dest="headers"
+    )
+
+    args, remainder = parser.parse_known_args()
 
     headers = DEFAULT_HEADERS.copy()
     if url is None:
@@ -448,9 +454,19 @@ def main():
     auth_header = get_authorization_header(config.root, config.discharge)
     headers.update(auth_header)
 
+
     # -s hides progress bar and errors, -S brings the errors back, -L follows
     # redirects, and --output - prints binary output to terminal
     arguments = ["curl", "-sSL", "--output", "-"]
+
+    print()
+    for item in args.headers:
+        try:
+            k, v = [t.strip() for t in item.split(":")]
+        except ValueError:
+            print('Invalid header: "{}"'.format(item))
+            return 1
+        headers[k.lower()] = v
 
     for header, value in headers.items():
         arguments.append("-H")
@@ -458,6 +474,11 @@ def main():
 
     arguments.extend(remainder)
     arguments.append(url)
+
+    print()
+    print()
+    print(arguments)
+    print()
 
     result = subprocess.run(arguments, stderr=subprocess.STDOUT)
 

--- a/surl/__init__.py
+++ b/surl/__init__.py
@@ -35,7 +35,7 @@ DEFAULT_HEADERS = {
     "user-agent": "surl/{}".format(os.environ.get("SNAP_VERSION", "devel")),
     "accept": "application/json, application/hal+json",
     "content-type": "application/json",
-    "ccache-control": "no-cache",
+    "cache-control": "no-cache",
 }
 
 CONSTANTS = {

--- a/surl/__init__.py
+++ b/surl/__init__.py
@@ -395,7 +395,7 @@ def get_client(web_login, store_env, store_type):
         if store_type == "snapcraft"
         else CONSTANTS[store_env]["pubgw_base_url"],
         storage_base_url="https://storage.staging.snapcraftcontent.com",
-        user_agent="surl/devel",
+        user_agent=DEFAULT_HEADERS["user-agent"],
         application_name="surl",
         environment_auth="CREDENTIALS",
         ephemeral=True,

--- a/surl/__init__.py
+++ b/surl/__init__.py
@@ -387,7 +387,7 @@ def get_client(web_login, store_env, store_type):
         if store_type == "snapcraft"
         else CONSTANTS[store_env]["pubgw_base_url"],
         storage_base_url="https://storage.staging.snapcraftcontent.com",
-        user_agent=DEFAULT_HEADERS["User-Agent"],
+        user_agent="surl/devel",
         application_name="surl",
         environment_auth="CREDENTIALS",
         ephemeral=True,
@@ -440,7 +440,14 @@ def main():
 
     # -s hides progress bar and errors, -S brings the errors back, -L follows
     # redirects, and --output - prints binary output to terminal
-    arguments = ["curl", "-sSL", "--output", "-", "-H", f"Authorization: {auth_header['Authorization']}"]
+    arguments = [
+        "curl",
+        "-sSL",
+        "--output",
+        "-",
+        "-H",
+        f"Authorization: {auth_header['Authorization']}",
+    ]
 
     arguments.extend(remainder)
     arguments.append(url)

--- a/surl/__init__.py
+++ b/surl/__init__.py
@@ -433,10 +433,8 @@ def main():
         return 1
     except CliDone:
         return 0
-    
-    parser.add_argument(
-        "-H", "--header", action="append", default=[], dest="headers"
-    )
+
+    parser.add_argument("-H", "--header", action="append", default=[], dest="headers")
 
     args, remainder = parser.parse_known_args()
 
@@ -454,12 +452,10 @@ def main():
     auth_header = get_authorization_header(config.root, config.discharge)
     headers.update(auth_header)
 
-
     # -s hides progress bar and errors, -S brings the errors back, -L follows
     # redirects, and --output - prints binary output to terminal
     arguments = ["curl", "-sSL", "--output", "-"]
 
-    print()
     for item in args.headers:
         try:
             k, v = [t.strip() for t in item.split(":")]
@@ -474,11 +470,6 @@ def main():
 
     arguments.extend(remainder)
     arguments.append(url)
-
-    print()
-    print()
-    print(arguments)
-    print()
 
     result = subprocess.run(arguments, stderr=subprocess.STDOUT)
 


### PR DESCRIPTION
Previously, when the user specified a header that was already specified by `surl` as a default header, the header would seemingly not get passed to `curl`. This particularly affected the passing of `Content-Type:`, but would also affect `Accept:`, `User-Agent:`, and `Cache-Control:`. This change merges the headers received from the user with the default headers (and with the headers previously specified, in the case the user specifies the same header multiple times on the command line), overwriting all values for the headers with the last value the user specifies.

This closes #43.