### PR TITLE
Fix authenticating with email

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="surl",
-    version="1.0.1",
+    version="1.0.2",
     author="Snap Store Team",
     author_email="daniel.manrique@canonical.com",
     url="https://github.com/canonical/surl",

--- a/surl/__init__.py
+++ b/surl/__init__.py
@@ -300,7 +300,7 @@ def get_config_from_cli(parser, auth_dir):
 
         store_client = get_client(args.web_login, store_env, store_type)
         if not args.web_login:
-            password = getpass(f"Password for {args.email}: ")
+            password = getpass.getpass(f"Password for {args.email}: ")
             if store_env == "production":
                 otp = input(f"Second-factor auth for {store_env}: ")
 


### PR DESCRIPTION
Turns out modules aren't callable.

The semi-mythical next version of `surl` will have at least some basic tests to catch something as simple as this mistake.