### PR TITLE
Local SCA URL is now http://sca-focal.lxd:8000

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="surl",
-    version="1.0.2",
+    version="1.0.3",
     author="Snap Store Team",
     author_email="daniel.manrique@canonical.com",
     url="https://github.com/canonical/surl",

--- a/surl/__init__.py
+++ b/surl/__init__.py
@@ -44,11 +44,15 @@ CONSTANTS = {
         "sso_base_url": os.environ.get(
             "SURL_SSO_BASE_URL", "https://login.staging.ubuntu.com"
         ),
-        "sca_base_url": os.environ.get("SURL_SCA_BASE_URL", "http://0.0.0.0:8000"),
+        "sca_base_url": os.environ.get(
+            "SURL_SCA_BASE_URL", "http://sca-focal.lxd:8000"
+        ),
         "pubgw_base_url": os.environ.get(
             "SURL_PUBGW_BASE_URL", "http://publishergw-focal.lxd:8010"
         ),
-        "api_base_url": os.environ.get("SURL_API_BASE_URL", "http://0.0.0.0:8000"),
+        "api_base_url": os.environ.get(
+            "SURL_API_BASE_URL", "http://sca-focal.lxd:8000"
+        ),
     },
     "staging": {
         "sso_location": "login.staging.ubuntu.com",


### PR DESCRIPTION
This allows running `surl` on the host machine of the lxd container, instead of in the lxd container itself.